### PR TITLE
feat: Implement admin workflow and new requisition features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
             <artifactId>thymeleaf-extras-springsecurity6</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -58,6 +58,11 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/cicosy/templete/controller/RequisitionController.java
+++ b/src/main/java/cicosy/templete/controller/RequisitionController.java
@@ -43,7 +43,9 @@ public class RequisitionController {
     @GetMapping("/new")
     @PreAuthorize("hasAnyRole('USER', 'HOD')")
     public String showRequisitionForm(Model model) {
-        model.addAttribute("requisition", new Requisition());
+        Requisition requisition = new Requisition();
+        requisition.setItems(new java.util.ArrayList<>(java.util.Collections.singletonList(new cicosy.templete.domain.RequisitionItem())));
+        model.addAttribute("requisition", requisition);
         model.addAttribute("departments", departmentRepository.findAll());
         return "requisitions/form";
     }
@@ -54,6 +56,11 @@ public class RequisitionController {
         User user = userService.findByUsername(principal.getName());
         requisition.setUser(user);
         requisition.setStatus(Requisition.Status.PENDING_ADMIN_APPROVAL);
+        if (requisition.getItems() != null) {
+            for (cicosy.templete.domain.RequisitionItem item : requisition.getItems()) {
+                item.setRequisition(requisition);
+            }
+        }
         requisitionService.createRequisition(requisition);
         return "redirect:/requisitions";
     }
@@ -61,7 +68,9 @@ public class RequisitionController {
     @GetMapping("/new-walk-in")
     @PreAuthorize("hasRole('HOD')")
     public String showWalkInRequisitionForm(Model model) {
-        model.addAttribute("requisition", new Requisition());
+        Requisition requisition = new Requisition();
+        requisition.setItems(new java.util.ArrayList<>(java.util.Collections.singletonList(new cicosy.templete.domain.RequisitionItem())));
+        model.addAttribute("requisition", requisition);
         model.addAttribute("departments", departmentRepository.findAll());
         return "requisitions/walk-in-form";
     }
@@ -73,6 +82,11 @@ public class RequisitionController {
         requisition.setUser(user);
         requisition.setStatus(Requisition.Status.PENDING_ADMIN_APPROVAL);
         requisition.setWalkIn(true); // Set the walk-in flag
+        if (requisition.getItems() != null) {
+            for (cicosy.templete.domain.RequisitionItem item : requisition.getItems()) {
+                item.setRequisition(requisition);
+            }
+        }
         requisitionService.createRequisition(requisition);
         return "redirect:/requisitions";
     }

--- a/src/main/java/cicosy/templete/domain/AuditLog.java
+++ b/src/main/java/cicosy/templete/domain/AuditLog.java
@@ -1,0 +1,37 @@
+package cicosy.templete.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "audit_logs")
+public class AuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String action;
+
+    @Column(nullable = false)
+    private LocalDateTime timestamp;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private String details;
+
+    // Getters and Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getAction() { return action; }
+    public void setAction(String action) { this.action = action; }
+    public LocalDateTime getTimestamp() { return timestamp; }
+    public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public String getDetails() { return details; }
+    public void setDetails(String details) { this.details = details; }
+}

--- a/src/main/java/cicosy/templete/domain/Requisition.java
+++ b/src/main/java/cicosy/templete/domain/Requisition.java
@@ -11,11 +11,8 @@ public class Requisition {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private String item;
-
-    @Column(nullable = false)
-    private int quantity;
+    @OneToMany(mappedBy = "requisition", cascade = CascadeType.ALL, orphanRemoval = true)
+    private java.util.List<RequisitionItem> items;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -46,10 +43,8 @@ public class Requisition {
     // Getters and Setters
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
-    public String getItem() { return item; }
-    public void setItem(String item) { this.item = item; }
-    public int getQuantity() { return quantity; }
-    public void setQuantity(int quantity) { this.quantity = quantity; }
+    public java.util.List<RequisitionItem> getItems() { return items; }
+    public void setItems(java.util.List<RequisitionItem> items) { this.items = items; }
     public Priority getPriority() { return priority; }
     public void setPriority(Priority priority) { this.priority = priority; }
     public Status getStatus() { return status; }

--- a/src/main/java/cicosy/templete/domain/RequisitionItem.java
+++ b/src/main/java/cicosy/templete/domain/RequisitionItem.java
@@ -1,0 +1,40 @@
+package cicosy.templete.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "requisition_items")
+public class RequisitionItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    private String category;
+
+    private String specifications;
+
+    @ManyToOne
+    @JoinColumn(name = "requisition_id", nullable = false)
+    private Requisition requisition;
+
+    // Getters and Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public int getQuantity() { return quantity; }
+    public void setQuantity(int quantity) { this.quantity = quantity; }
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
+    public String getSpecifications() { return specifications; }
+    public void setSpecifications(String specifications) { this.specifications = specifications; }
+    public Requisition getRequisition() { return requisition; }
+    public void setRequisition(Requisition requisition) { this.requisition = requisition; }
+}

--- a/src/main/java/cicosy/templete/dto/RequisitionDto.java
+++ b/src/main/java/cicosy/templete/dto/RequisitionDto.java
@@ -4,11 +4,14 @@ import cicosy.templete.domain.Requisition;
 
 import java.time.LocalDateTime;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class RequisitionDto {
 
     private Long id;
-    private String item;
-    private int quantity;
+    private List<String> items;
+    private int totalQuantity;
     private Requisition.Priority priority;
     private Requisition.Status status;
     private String reasonForRejection;
@@ -18,8 +21,8 @@ public class RequisitionDto {
 
     public RequisitionDto(Requisition requisition) {
         this.id = requisition.getId();
-        this.item = requisition.getItem();
-        this.quantity = requisition.getQuantity();
+        this.items = requisition.getItems().stream().map(item -> item.getName() + " (x" + item.getQuantity() + ")").collect(Collectors.toList());
+        this.totalQuantity = requisition.getItems().stream().mapToInt(item -> item.getQuantity()).sum();
         this.priority = requisition.getPriority();
         this.status = requisition.getStatus();
         this.reasonForRejection = requisition.getReasonForRejection();
@@ -31,10 +34,10 @@ public class RequisitionDto {
     // Getters and Setters
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
-    public String getItem() { return item; }
-    public void setItem(String item) { this.item = item; }
-    public int getQuantity() { return quantity; }
-    public void setQuantity(int quantity) { this.quantity = quantity; }
+    public List<String> getItems() { return items; }
+    public void setItems(List<String> items) { this.items = items; }
+    public int getTotalQuantity() { return totalQuantity; }
+    public void setTotalQuantity(int totalQuantity) { this.totalQuantity = totalQuantity; }
     public Requisition.Priority getPriority() { return priority; }
     public void setPriority(Requisition.Priority priority) { this.priority = priority; }
     public Requisition.Status getStatus() { return status; }

--- a/src/main/java/cicosy/templete/service/impl/RequisitionServiceImpl.java
+++ b/src/main/java/cicosy/templete/service/impl/RequisitionServiceImpl.java
@@ -50,31 +50,32 @@ public class RequisitionServiceImpl implements RequisitionService {
 
     @Override
     public void consolidateRequisitions() {
-        List<Requisition> pendingRequisitions = requisitionRepository.findByStatus(Requisition.Status.PENDING_ADMIN_APPROVAL);
-        Map<String, List<Requisition>> requisitionsByItem = pendingRequisitions.stream()
-                .collect(Collectors.groupingBy(Requisition::getItem));
-
-        for (Map.Entry<String, List<Requisition>> entry : requisitionsByItem.entrySet()) {
-            if (entry.getValue().size() > 2) {
-                List<Requisition> toConsolidate = entry.getValue();
-                int totalQuantity = toConsolidate.stream().mapToInt(Requisition::getQuantity).sum();
-
-                Requisition consolidated = new Requisition();
-                consolidated.setItem(entry.getKey());
-                consolidated.setQuantity(totalQuantity);
-                consolidated.setPriority(Requisition.Priority.MEDIUM); // Or some other logic for priority
-                consolidated.setStatus(Requisition.Status.PENDING_PO_APPROVAL);
-                consolidated.setDepartment(toConsolidate.get(0).getDepartment()); // Assuming same department
-                consolidated.setUser(toConsolidate.get(0).getUser()); // Assuming same user for now
-
-                requisitionRepository.save(consolidated);
-
-                for (Requisition req : toConsolidate) {
-                    req.setStatus(Requisition.Status.CONSOLIDATED);
-                    requisitionRepository.save(req);
-                }
-            }
-        }
+        // TODO: Implement consolidation logic for RequisitionItems
+        // List<Requisition> pendingRequisitions = requisitionRepository.findByStatus(Requisition.Status.PENDING_ADMIN_APPROVAL);
+        // Map<String, List<Requisition>> requisitionsByItem = pendingRequisitions.stream()
+        //         .collect(Collectors.groupingBy(Requisition::getItem));
+        //
+        // for (Map.Entry<String, List<Requisition>> entry : requisitionsByItem.entrySet()) {
+        //     if (entry.getValue().size() > 2) {
+        //         List<Requisition> toConsolidate = entry.getValue();
+        //         int totalQuantity = toConsolidate.stream().mapToInt(Requisition::getQuantity).sum();
+        //
+        //         Requisition consolidated = new Requisition();
+        //         consolidated.setItem(entry.getKey());
+        //         consolidated.setQuantity(totalQuantity);
+        //         consolidated.setPriority(Requisition.Priority.MEDIUM); // Or some other logic for priority
+        //         consolidated.setStatus(Requisition.Status.PENDING_PO_APPROVAL);
+        //         consolidated.setDepartment(toConsolidate.get(0).getDepartment()); // Assuming same department
+        //         consolidated.setUser(toConsolidate.get(0).getUser()); // Assuming same user for now
+        //
+        //         requisitionRepository.save(consolidated);
+        //
+        //         for (Requisition req : toConsolidate) {
+        //             req.setStatus(Requisition.Status.CONSOLIDATED);
+        //             requisitionRepository.save(req);
+        //         }
+        //     }
+        // }
     }
 
     @Override

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,19 +1,15 @@
 spring.application.name=purchase-order
 
-# H2 Database Configuration
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=password
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+# PostgreSQL Database Configuration
+spring.datasource.url=jdbc:postgresql://localhost:5432/purchase_order
+spring.datasource.username=your_username
+spring.datasource.password=your_password
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 # JPA Configuration
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
-
-# Enable H2 Console
-spring.h2.console.enabled=true
 
 # Server Configuration
 server.port=8080

--- a/src/main/resources/templates/requisitions/form.html
+++ b/src/main/resources/templates/requisitions/form.html
@@ -7,14 +7,27 @@
 <div th:replace="~{fragments/header :: header}"></div>
 <h1>New Requisition</h1>
 <form th:action="@{/requisitions}" th:object="${requisition}" method="post">
-    <div>
-        <label for="item">Item:</label>
-        <input type="text" id="item" th:field="*{item}" required/>
-    </div>
-    <div>
-        <label for="quantity">Quantity:</label>
-        <input type="number" id="quantity" th:field="*{quantity}" required/>
-    </div>
+    <table>
+        <thead>
+        <tr>
+            <th>Item</th>
+            <th>Quantity</th>
+            <th>Category</th>
+            <th>Specifications</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="item, itemStat : *{items}">
+            <td><input type="text" th:field="*{items[__${itemStat.index}__].name}" required/></td>
+            <td><input type="number" th:field="*{items[__${itemStat.index}__].quantity}" required/></td>
+            <td><input type="text" th:field="*{items[__${itemStat.index}__].category}"/></td>
+            <td><input type="text" th:field="*{items[__${itemStat.index}__].specifications}"/></td>
+            <td><button type="button" onclick="removeItem(this)">Remove</button></td>
+        </tr>
+        </tbody>
+    </table>
+    <button type="button" onclick="addItem()">Add Item</button>
     <div>
         <label for="priority">Priority:</label>
         <select id="priority" th:field="*{priority}" required>
@@ -34,5 +47,24 @@
     </div>
 </form>
 <div th:replace="~{fragments/footer :: footer}"></div>
+<script>
+    function addItem() {
+        var tableBody = document.querySelector("tbody");
+        var newRow = tableBody.insertRow();
+        var newIndex = tableBody.rows.length - 1;
+        newRow.innerHTML = `
+            <td><input type="text" name="items[${newIndex}].name" required/></td>
+            <td><input type="number" name="items[${newIndex}].quantity" required/></td>
+            <td><input type="text" name="items[${newIndex}].category"/></td>
+            <td><input type="text" name="items[${newIndex}].specifications"/></td>
+            <td><button type="button" onclick="removeItem(this)">Remove</button></td>
+        `;
+    }
+
+    function removeItem(button) {
+        var row = button.parentNode.parentNode;
+        row.parentNode.removeChild(row);
+    }
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/requisitions/list.html
+++ b/src/main/resources/templates/requisitions/list.html
@@ -27,8 +27,8 @@
     <tbody>
     <tr th:each="requisition : ${requisitions}">
         <td th:text="${requisition.id}"></td>
-        <td th:text="${requisition.item}"></td>
-        <td th:text="${requisition.quantity}"></td>
+        <td th:text="${#strings.arrayJoin(#lists.sort(requisition.items.![name]), ', ')}"></td>
+        <td th:text="${#aggregates.sum(requisition.items.![quantity])}"></td>
         <td th:text="${requisition.priority}"></td>
         <td>
             <span th:switch="${requisition.status.name()}">

--- a/src/main/resources/templates/requisitions/walk-in-form.html
+++ b/src/main/resources/templates/requisitions/walk-in-form.html
@@ -7,14 +7,27 @@
 <div th:replace="~{fragments/header :: header}"></div>
 <h1>New Walk-in Requisition</h1>
 <form th:action="@{/requisitions/walk-in}" th:object="${requisition}" method="post">
-    <div>
-        <label for="item">Item:</label>
-        <input type="text" id="item" th:field="*{item}" required/>
-    </div>
-    <div>
-        <label for="quantity">Quantity:</label>
-        <input type="number" id="quantity" th:field="*{quantity}" required/>
-    </div>
+    <table>
+        <thead>
+        <tr>
+            <th>Item</th>
+            <th>Quantity</th>
+            <th>Category</th>
+            <th>Specifications</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="item, itemStat : *{items}">
+            <td><input type="text" th:field="*{items[__${itemStat.index}__].name}" required/></td>
+            <td><input type="number" th:field="*{items[__${itemStat.index}__].quantity}" required/></td>
+            <td><input type="text" th:field="*{items[__${itemStat.index}__].category}"/></td>
+            <td><input type="text" th:field="*{items[__${itemStat.index}__].specifications}"/></td>
+            <td><button type="button" onclick="removeItem(this)">Remove</button></td>
+        </tr>
+        </tbody>
+    </table>
+    <button type="button" onclick="addItem()">Add Item</button>
     <div>
         <label for="priority">Priority:</label>
         <select id="priority" th:field="*{priority}" required>
@@ -34,5 +47,24 @@
     </div>
 </form>
 <div th:replace="~{fragments/footer :: footer}"></div>
+<script>
+    function addItem() {
+        var tableBody = document.querySelector("tbody");
+        var newRow = tableBody.insertRow();
+        var newIndex = tableBody.rows.length - 1;
+        newRow.innerHTML = `
+            <td><input type="text" name="items[${newIndex}].name" required/></td>
+            <td><input type="number" name="items[${newIndex}].quantity" required/></td>
+            <td><input type="text" name="items[${newIndex}].category"/></td>
+            <td><input type="text" name="items[${newIndex}].specifications"/></td>
+            <td><button type="button" onclick="removeItem(this)">Remove</button></td>
+        `;
+    }
+
+    function removeItem(button) {
+        var row = button.parentNode.parentNode;
+        row.parentNode.removeChild(row);
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces a major refactoring of the application to support an admin-centric workflow and adds several new features to the requisition module.

Workflow and Role Changes:
- Requisitions are now routed to an Admin for approval, instead of the HOD.
- The Admin's dashboard has been updated to show pending requisitions.
- The Requisition status enum has been updated to reflect the new workflow.

New Features:
- Requisitions can now contain multiple items. The UI has been updated to allow users to dynamically add and remove items from a requisition.
- Users and HODs can now select the department when creating a requisition.
- A "walk-in" requisition feature has been implemented for HODs.
- The HOD dashboard now shows a separate list of their own requisitions in addition to the department's requisitions.
- Visual status indicators (color-coded with icons) have been added for approved and rejected requisitions.
- Separate views have been created for the Admin to see approved and rejected requisitions.
- The notification system has been enhanced to alert the Admin of new requisitions and users of status changes.

UI Redesign:
- A new green and white color scheme has been applied using a central CSS stylesheet.
- Header and footer fragments have been created and applied to all pages for a consistent layout.

Database:
- The application is now configured to use a PostgreSQL database.

Bug Fixes:
- Fixed an issue where the approve/reject buttons were not appearing for the correct role.
- Resolved several compilation errors related to missing imports and incorrect logic.