### PR TITLE
Fix compilation warnings and configure MySQL

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,7 @@ spring.application.name=purchase-order
 spring.datasource.url=jdbc:mysql://localhost:3306/purchaseorder
 spring.datasource.username=root
 spring.datasource.password=root
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 # JPA Configuration


### PR DESCRIPTION
- Replaced the deprecated `@EnableGlobalMethodSecurity` with `@EnableMethodSecurity` to resolve compilation warnings.
- Switched the database from PostgreSQL to MySQL as requested by the user.
- Updated `pom.xml` to include the `mysql-connector-j` dependency.
- Updated `application.properties` with the new MySQL connection details.
- Added the H2 dependency back with a `test` scope to ensure tests can run independently.
- Explicitly set the MySQL driver class name in `application.properties` to prevent class loading issues.