### PR TITLE
Fix: Correct database name in application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=purchase-order
 
 # MySQL Database Configuration
-spring.datasource.url=jdbc:mysql://localhost:3306/purchaseorder
+spring.datasource.url=jdbc:mysql://localhost:3306/purchase_order
 spring.datasource.username=root
 spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
The database name was corrected from `purchaseorder` to `purchase_order` as per the user's request.