### PR TITLE
Fix: Correct view path in RequisitionRequestController

### DIFF
--- a/src/main/java/cicosy/templete/controller/RequisitionRequestController.java
+++ b/src/main/java/cicosy/templete/controller/RequisitionRequestController.java
@@ -42,7 +42,7 @@ public class RequisitionRequestController {
         }
         
         model.addAttribute("requests", requests);
-        return "requests/list";
+        return "requisitions/list";
     }
 
     @GetMapping("/new")


### PR DESCRIPTION
Corrected the return path in the `listRequests` method of `RequisitionRequestController` to point to the correct view. This fixes a white label error that occurred after an HOD approved or rejected a request.