### PR TITLE
Fix: Correct view path for walk-in request form

### DIFF
--- a/src/main/java/cicosy/templete/controller/RequisitionRequestController.java
+++ b/src/main/java/cicosy/templete/controller/RequisitionRequestController.java
@@ -93,7 +93,7 @@ public class RequisitionRequestController {
         model.addAttribute("request", new RequisitionRequest());
         model.addAttribute("departments", departmentRepository.findAll());
         model.addAttribute("priorities", RequisitionRequest.Priority.values());
-        return "requests/walk-in-form";
+        return "requisitions/walk-in-form";
     }
 
     @PostMapping("/walk-in")


### PR DESCRIPTION
Corrected the return path in the `showWalkInRequestForm` method of `RequisitionRequestController` to point to the correct view. This fixes a white label error that occurred when the HOD clicked on the 'Walk-in Request' button.